### PR TITLE
remove city and postcode from hashes

### DIFF
--- a/deduplicator/src/deduplicator.rs
+++ b/deduplicator/src/deduplicator.rs
@@ -256,6 +256,10 @@ impl<'db> DbInserter<'db> {
                     let rank = ranking(&address);
                     let hashes: Vec<_> = hash_address(&address).collect();
 
+                    if hashes.is_empty() {
+                        eprintln!("found an address that can't be hashed: {:?}", address);
+                    }
+
                     hash_sender
                         .send((address, rank, hashes))
                         .expect("failed sending hashes: channel may have closed too early");

--- a/deduplicator/src/tests.rs
+++ b/deduplicator/src/tests.rs
@@ -94,8 +94,12 @@ fn remove_exact_duplicates() -> rusqlite::Result<()> {
     // Read input database
     let input_addresses = load_addresses_from_db(&load_dump(&DB_NO_DUPES.into())?)?;
     let mut dedupe = Deduplicator::new(tmp_dir.path().join("addresses.db"))?;
-    insert_addresses(&mut dedupe, input_addresses.clone())?;
-    insert_addresses(&mut dedupe, input_addresses.clone())?;
+
+    // Insert all addresses 10 times
+    for _ in 0..10 {
+        insert_addresses(&mut dedupe, input_addresses.clone())?;
+    }
+
     dedupe.compute_duplicates()?;
     dedupe.apply_and_clean(false)?;
 


### PR DESCRIPTION
Removing city and postcode from produced hashes helps to reduce the amount of hashes we have to deal with. It will also help avoiding huge collisions on addresses with invalid city name, it appears that a placeholder was used in some regions of OSM.

When testing imports of OSM (349MB) and OpenAddress (773MB) over Belgium:
 - the whole process runs in 1h30 (read sources + compute hashes + deduplicates + clean database)
 - the main de-duplication step takes 1h (CPU-bounded)
 - 7M out of 12M addresses are removed

-| master | deduplication-less-hashes
:-:|:-:|:-:
number of hashes | 277M | 243M
temporary database size | 11GB | 9.2GB