### PR TITLE
Add new step to get the ways from the relations that we discarded before

### DIFF
--- a/importers/osm/Cargo.lock
+++ b/importers/osm/Cargo.lock
@@ -284,6 +284,7 @@ dependencies = [
  "geos",
  "osmpbfreader",
  "rusqlite",
+ "time 0.2.6",
  "tools",
 ]
 
@@ -322,6 +323,17 @@ name = "pkg-config"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecd45702f76d6d3c75a80564378ae228a85f0b59d2f3ed43c91b4a69eb2ebfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -411,7 +423,18 @@ dependencies = [
  "libsqlite3-sys",
  "lru-cache",
  "memchr",
- "time",
+ "time 0.1.42",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3bba175698996010c4f6dce5e7f173b6eb781fce25d2cfc45e27091ce0b79f6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -457,6 +480,38 @@ dependencies = [
  "libc",
  "redox_syscall",
  "winapi",
+]
+
+[[package]]
+name = "time"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcb8742444475438c500d017736dd7cf3d9c9dd1f0153cfa4af428692484e3ef"
+dependencies = [
+ "rustversion",
+ "time-macros",
+]
+
+[[package]]
+name = "time-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9b6e9f095bc105e183e3cd493d72579be3181ad4004fceb01adbe9eecab2d"
+dependencies = [
+ "proc-macro-hack",
+ "time-macros-impl",
+]
+
+[[package]]
+name = "time-macros-impl"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e987cfe0537f575b5fc99909de6185f6c19c3ad8889e2275e686a873d0869ba1"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/importers/osm/Cargo.toml
+++ b/importers/osm/Cargo.toml
@@ -10,6 +10,7 @@ geos = "5.0"
 osmpbfreader = "0.13.4"
 rusqlite = "0.20"
 tools = { path = "../../tools" }
+time = { version = "0.2", features = ["std"] }
 
 [[bin]]
 name = "osm"


### PR DESCRIPTION
Relations can contain relations and ways. Before, we just kept the nodes, now we keep track of the sub ways and sub relations to prevent filtering them out when we read the pbf file a second time.

This new first step took 40 minutes on my computer when running on europe. The memory consumption didn't seem to grow much. Most of the time is still spent on reading the pbf file.