### PR TITLE
test deduplication for non exact matches + more laxist duplication criteria

### DIFF
--- a/deduplicator/README.md
+++ b/deduplicator/README.md
@@ -49,7 +49,8 @@ true:
 
  - The distance between the two addresses is less than 100 meters and according
    to libpostal they have the same house number and are likely to be in the
-   same street.
+   same street. If there is less than 10 meters between the two addresses,
+   libpostal is allowed to only output `PossibleDuplicate` for street name.
 
  - According to libpostal, the two addresses have the same house number, the
    same street name and the same city (or postal code).

--- a/deduplicator/data/tests/with_dupes.sql
+++ b/deduplicator/data/tests/with_dupes.sql
@@ -1,0 +1,54 @@
+PRAGMA foreign_keys=OFF;
+BEGIN TRANSACTION;
+CREATE TABLE addresses(
+                lat REAL NOT NULL,
+                lon REAL NOT NULL,
+                number TEXT,
+                street TEXT NOT NULL,
+                unit TEXT,
+                city TEXT,
+                district TEXT,
+                region TEXT,
+                postcode TEXT,
+                PRIMARY KEY (lat, lon, number, street, city)
+            );
+
+-- 10 addresses with non-trivial duplicatas
+
+INSERT INTO addresses VALUES(48.85504,2.22249,'65','Quai Marcel Dassault',NULL,'Saint-Cloud',NULL,NULL,'92210');
+INSERT INTO addresses VALUES(48.85497,2.22255,'65','quai marcel dassault',NULL,'saint cloud',NULL,NULL,'92210');
+INSERT INTO addresses VALUES(48.85504,2.22248,'65','quai marcel dassault',NULL,NULL,NULL,NULL,NULL);
+
+INSERT INTO addresses VALUES(44.18536,0.66359,'1500','Avenue du Docteur Jean Noguès',NULL,'Boé',NULL,NULL,'47550');
+INSERT INTO addresses VALUES(44.18532,0.66367,'1500','Avenue Dr. Jean Noguès',NULL,'Boé',NULL,NULL,'47550');
+INSERT INTO addresses VALUES(44.18535,0.66366,'1500','av. du dr. jean noguès',NULL,NULL,NULL,NULL,NULL);
+
+INSERT INTO addresses VALUES(48.99685,2.18891,'177','Boulevard Victor Bordier',NULL,'Montigny-lès-Cormeilles',NULL,NULL,'95370');
+INSERT INTO addresses VALUES(48.99682,2.18897,'177','Bd. Victor Bordier',NULL,NULL,NULL,NULL,NULL);
+INSERT INTO addresses VALUES(48.99686,2.18893,'177','boulevard victor bordier',NULL,NULL,NULL,NULL,NULL);
+
+INSERT INTO addresses VALUES(45.69705,4.82488,'126','Boulevard de l''Europe',NULL,NULL,NULL,NULL,'69310');
+INSERT INTO addresses VALUES(45.69707,4.82488,'126','Boulevard de l Europe',NULL,NULL,NULL,NULL,NULL);
+INSERT INTO addresses VALUES(45.69700,4.82497,'126','bvd de l europe',NULL,NULL,NULL,NULL,'69310');
+
+INSERT INTO addresses VALUES(45.70583,4.87766,'61','Avenue De La République',NULL,NULL,NULL,NULL,NULL);
+INSERT INTO addresses VALUES(45.70579,4.87765,'61','av. république',NULL,NULL,NULL,NULL,NULL);
+
+INSERT INTO addresses VALUES(44.08969,6.23707,'8','Avenue du 8 Mai 1945',NULL,'Digne-les-Bains',NULL,NULL,'04000');
+INSERT INTO addresses VALUES(44.08976,6.23711,'8','Avenue du 8 Mai 1945',NULL,'Digne-les-Bains',NULL,NULL,'04000');
+INSERT INTO addresses VALUES(44.08978,6.23712,'8','Avenue du 8 Mai 1945',NULL,'Digne-les-Bains',NULL,NULL,'04000');
+
+INSERT INTO addresses VALUES(48.94847,2.34279,'53','Route de Saint-Leu',NULL,'Épinay-sur-Seine',NULL,NULL,'93800');
+INSERT INTO addresses VALUES(48.94840,2.34275,'53','route de saint leu',NULL,'Épinay-sur-Seine',NULL,NULL,'93800');
+INSERT INTO addresses VALUES(48.94840,2.34284,'53','rt. saint leu',NULL,'Épinay-sur-Seine',NULL,NULL,'93800');
+
+INSERT INTO addresses VALUES(49.03465,3.39182,'26','Avenue de l''Europe',NULL,'Château-Thierry',NULL,NULL,'02400');
+INSERT INTO addresses VALUES(49.03460,3.39190,'26','av. de l''europe',NULL,NULL,NULL,NULL,'02400');
+
+INSERT INTO addresses VALUES(49.03460,3.3925,'26','Route de l''Europe',NULL,'Château-Thierry',NULL,NULL,'02400');
+INSERT INTO addresses VALUES(49.03460,3.3937,'26','route de l europe',NULL,'Château-Thierry',NULL,NULL,'02400');
+
+INSERT INTO addresses VALUES(49.03463,3.3935,'27','route de l europe',NULL,'Château-Thierry',NULL,NULL,'02400');
+INSERT INTO addresses VALUES(49.03460,3.3935,'27','route de l''europe',NULL,'Château-Thierry',NULL,NULL,NULL);
+
+COMMIT;

--- a/deduplicator/src/deduplicator.rs
+++ b/deduplicator/src/deduplicator.rs
@@ -6,11 +6,11 @@ use std::thread;
 
 use crossbeam_channel as channel;
 use importer_openaddress::OpenAddress;
-use tools::Address;
 use itertools::Itertools;
 use libflate::gzip::Encoder;
 use prog_rs::prelude::*;
 use rusqlite::DropBehavior;
+use tools::Address;
 
 use crate::db_hashes::{DbHashes, HashIterItem};
 use crate::dedupe::{hash_address, is_duplicate};
@@ -47,7 +47,8 @@ impl Deduplicator {
 
         tprint!(
             "Compute hash collisions ({} addresses, {} hashes)",
-            count_addresses_before, count_hashes
+            count_addresses_before,
+            count_hashes
         );
 
         let conn_get_collisions = self.db.get_conn()?;
@@ -267,7 +268,8 @@ impl<'db> DbInserter<'db> {
                     let hashes: Vec<_> = hash_address(&address).collect();
 
                     if hashes.is_empty() {
-                        teprint!("found an address that can't be hashed: {:?}", address);
+                        teprint!("ignoring an address that can't be hashed: {:?}", address);
+                        continue;
                     }
 
                     hash_sender

--- a/deduplicator/src/main.rs
+++ b/deduplicator/src/main.rs
@@ -65,7 +65,7 @@ struct Params {
     osm_db: Vec<PathBuf>,
 
     /// Path for output database.
-    #[structopt(short, long, default_value = "addresses.db")]
+    #[structopt(long, default_value = "addresses.db")]
     output_db: PathBuf,
 
     /// Keep construction tables in the output database


### PR DESCRIPTION
Add a few handmade test of addresses with non trivial duplication.

### Criterion change

I also suggested a new change to the duplication criteria. If two addresses are less than 10 meters apart from each other, then the criterion is less strict about street name similarity, this appears to help libpostal with these two cases:

 - removal of articles like in "Avenue du Général Leclerc" <-> "Avenue Général Leclerc"
 - name variations: "route" <-> "rue"