### PR TITLE
osm-import: fix swaped way coordinates

### DIFF
--- a/importers/osm/src/lib.rs
+++ b/importers/osm/src/lib.rs
@@ -367,7 +367,7 @@ fn get_way_lat_lon(sub_objs: &[Cow<OsmObj>]) -> Option<(f64, f64)> {
     );
     if let Ok(geom) = Geometry::new_from_wkt(&polygon).and_then(|g| g.get_centroid()) {
         match (geom.get_x(), geom.get_y()) {
-            (Ok(lon), Ok(lat)) => return Some((lon, lat)),
+            (Ok(lon), Ok(lat)) => return Some((lat, lon)),
             _ => {}
         };
     }


### PR DESCRIPTION
Some lontitude / lattitude were swaped in the output. It may also be interesting to add a test to address this kind of issue.