### PR TITLE
Cache compilation on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,64 +5,76 @@ rust:
   - nightly
   - stable
 env:
-  - TEST_TOOLS=1
-  - TEST_IMPORTERS=1
-  - TEST_DEDUPLICATOR=1
-  - TEST_DEDUPLICATOR_COMPLETE=1
+  global:
+    - CARGO_TARGET_DIR=/home/travis/.cargo/target
+  jobs:
+    - TEST_TOOLS=1
+    - TEST_IMPORTERS=1
+    - TEST_DEDUPLICATOR=1
+    - TEST_DEDUPLICATOR_COMPLETE=1
+
+cache:
+  cargo: true
+  directories:
+    # It appears that "ccache: true" would activate sccache instead of ccache
+    # for Rust environment.
+    - /home/travis/.ccache
 
 addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
     packages:
+      - ccache
       - gcc-4.8
 
 before_install:
-  - export CC="gcc-4.8"
-  - if [ "$TEST_DEDUPLICATOR" == "1" ] || [ "$TEST_DEDUPLICATOR_COMPLETE" == "1" ]; then
-    git clone https://github.com/openvenues/libpostal;
-    cd libpostal;
-    ./bootstrap.sh;
-    ./configure --datadir=$(pwd)/data;
-    sudo make install;
-    cd ..;
-    sudo ldconfig;
-    fi
   - if [ "$TRAVIS_RUST_VERSION" == "stable" ] && [ "$TRAVIS_PULL_REQUEST_BRANCH" == "" ] && [ "$TRAVIS_BRANCH" == "master" ] && [ "$TEST_TOOLS" == "1" ]; then
-    echo "$DOCKER_TOKEN" | docker login -u "$DOCKER_USERNAME" --password-stdin;
+      echo "$DOCKER_TOKEN" | docker login -u "$DOCKER_USERNAME" --password-stdin;
+    fi
+
+install:
+  - if [ "$TEST_DEDUPLICATOR" == "1" ] || [ "$TEST_DEDUPLICATOR_COMPLETE" == "1" ]; then
+      git clone https://github.com/openvenues/libpostal;
+      cd libpostal;
+      ./bootstrap.sh;
+      ./configure --datadir=$(pwd)/data;
+      CC="ccache gcc-4.8" ./configure --datadir=$(pwd)/data;
+      sudo make install;
+      cd ..;
+      sudo ldconfig;
     fi
 
 script:
   - rustc --version
   # Check for tools
   - if [ "$TEST_TOOLS" == "1" ]; then
-    cd tools && cargo check;
-    cargo test;
-    cd ..;
+      (cd tools && cargo check)
+      && (cd tools && cargo test);
     fi
   # Check for importers
   - if [ "$TEST_IMPORTERS" == "1" ]; then
-    cd importers/osm && cargo check;
-    cargo test;
-    cd ../..;
-    cd importers/bano && cargo check;
-    cargo test;
-    cd ../..;
-    cd importers/openaddresses && cargo check;
-    cargo test;
-    cd ../..;
+      (cd importers/osm && cargo check)
+      && (cd importers/osm && cargo test);
+      (cd importers/bano && cargo check)
+      && (cd importers/bano && cargo test);
+      (cd importers/openaddresses && cargo check)
+      && (cd importers/openaddresses && cargo test);
     fi
   # Check for deduplicator
   - if [ "$TEST_DEDUPLICATOR" == "1" ]; then
-    cd deduplicator && cargo check;
-    cargo test;
-    cd ..;
+      (cd deduplicator && cargo check)
+      && (cd deduplicator && cargo test);
     fi
   # Run a complete deduplication
   - if [ "$TEST_DEDUPLICATOR_COMPLETE" == "1"]; then
-    (cd deduplicator && cargo run --release -- --osm ../importers/osm/test-files/relations_ways.pbf --output-csv test.csv);
+      (cd deduplicator && cargo run -- --osm ../importers/osm/test-files/relations_ways.pbf --output-csv test.csv);
     fi
   - if [ "$TRAVIS_RUST_VERSION" == "stable" ] && [ "$TRAVIS_PULL_REQUEST_BRANCH" == "" ] && [ "$TRAVIS_BRANCH" == "master" ] && [ "$TEST_TOOLS" == "1" ]; then
-    docker build --label "org.label-schema.vcs-ref=$TRAVIS_COMMIT" -t qwantresearch/addresses-importer .;
-    docker push qwantresearch/addresses-importer;
+      docker build --label "org.label-schema.vcs-ref=$TRAVIS_COMMIT" -t qwantresearch/addresses-importer .;
+      docker push qwantresearch/addresses-importer;
     fi
+
+before_cache:
+  - du -sh /home/travis/.cargo/*
+  - ccache --show-stats


### PR DESCRIPTION
Cache build data for cargo and gcc.

This should speedup consequently build time (20min down to 8min) and reduce the energy footprint of this repository! :tada: 

For some reason some Rust crates still have to be recompiled for each build, I'd be interested to understand why?