### PR TITLE
More readable logs

### DIFF
--- a/deduplicator/src/main.rs
+++ b/deduplicator/src/main.rs
@@ -120,7 +120,7 @@ fn main() -> rusqlite::Result<()> {
     let mut deduplication = Deduplicator::new(params.output_db, Some(params.cache_size))?;
 
     for (source, path) in db_sources {
-        tprint!("Loading {:?} addresses from database {:?}", source, path);
+        tprintln!("Loading {:?} addresses from database {:?}...", source, path);
 
         load_from_sqlite(
             &mut deduplication,
@@ -131,7 +131,7 @@ fn main() -> rusqlite::Result<()> {
     }
 
     for (source, path) in raw_sources {
-        tprint!("Loading {:?} addresses from path {:?}", source, path);
+        tprintln!("Loading {:?} addresses from path {:?}...", source, path);
 
         let filter = move |addr: &Address| source.filter(&addr);
         let ranking = move |addr: &Address| source.ranking(&addr);
@@ -146,19 +146,22 @@ fn main() -> rusqlite::Result<()> {
 
     // --- Apply deduplication
 
+    tprintln!("Deduplication...");
     deduplication.compute_duplicates()?;
+
+    tprintln!("Cleaning...");
     deduplication.apply_and_clean(params.keep)?;
 
     // --- Dump CSV
 
     if let Some(output_csv) = params.output_csv {
-        tprint!("Write CSV");
+        tprintln!("Write CSV...");
         let file = File::create(output_csv).expect("failed to create dump file");
         deduplication.openaddresses_dump(file)?;
     }
 
     if let Some(compressed_csv) = params.output_compressed_csv {
-        tprint!("Write compressed CSV");
+        tprintln!("Write compressed CSV...");
         let file = File::create(compressed_csv).expect("failed to create dump file");
         let mut encoder = gzip::Encoder::new(file).expect("failed to init gzip encoder");
         deduplication.openaddresses_dump(&mut encoder)?;

--- a/deduplicator/src/utils.rs
+++ b/deduplicator/src/utils.rs
@@ -4,10 +4,10 @@ use std::path::PathBuf;
 
 use crate::deduplicator::Deduplicator;
 
-use tools::{Address, CompatibleDB};
 use libsqlite3_sys::ErrorCode::ConstraintViolation;
 use prog_rs::prelude::*;
 use rusqlite::{Connection, NO_PARAMS};
+use tools::{Address, CompatibleDB};
 
 pub fn field_compare<T>(
     field1: &Option<T>,
@@ -90,8 +90,9 @@ where
         .progress()
         .with_iter_size(nb_addresses)
         .with_prefix(format!("{:<45}", format!("{:?}", path)))
+        .with_output_stream(prog_rs::OutputStream::StdErr)
         .filter_map(|addr| {
-            addr.map_err(|e| teprint!("failed to read address from DB: {}", e))
+            addr.map_err(|e| teprintln!("Failed to read address from DB: {}", e))
                 .ok()
         });
 

--- a/importers/bano/src/lib.rs
+++ b/importers/bano/src/lib.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use std::str::FromStr;
 
 use csv::ReaderBuilder;
-use tools::{teprint, tprint, Address, CompatibleDB};
+use tools::{teprintln, tprintln, Address, CompatibleDB};
 
 macro_rules! get {
     ($index:expr, $records:expr) => {
@@ -21,7 +21,9 @@ macro_rules! get_f64 {
 }
 
 pub fn import_addresses<P: AsRef<Path>, T: CompatibleDB>(file_path: P, db: &mut T) {
-    tprint!("Reading `{}`...", file_path.as_ref().display());
+    teprintln!("[BANO] Reading `{}`", file_path.as_ref().display());
+    let count_before = db.get_nb_addresses();
+
     let file = File::open(file_path).expect("cannot open file");
     let rdr = ReaderBuilder::new().has_headers(false).from_reader(file);
 
@@ -29,7 +31,7 @@ pub fn import_addresses<P: AsRef<Path>, T: CompatibleDB>(file_path: P, db: &mut 
         let x = match x {
             Ok(x) => x,
             Err(e) => {
-                teprint!("invalid record found: {}", e);
+                teprintln!("[BANO] Invalid record found: {}", e);
                 continue;
             }
         };
@@ -46,5 +48,11 @@ pub fn import_addresses<P: AsRef<Path>, T: CompatibleDB>(file_path: P, db: &mut 
             postcode: get!(3, x).map(|x| x.to_owned()),
         });
     }
-    tprint!("Done!");
+
+    let count_after = db.get_nb_addresses();
+    tprintln!(
+        "[BANO] Added {} addresses (total: {})",
+        count_after - count_before,
+        count_after
+    );
 }

--- a/importers/bano/src/main.rs
+++ b/importers/bano/src/main.rs
@@ -1,25 +1,26 @@
 use std::env;
-use tools::{CompatibleDB, DB, tprint};
+use tools::{teprintln, tprintln, CompatibleDB, DB};
 
 fn main() {
     let args = env::args().collect::<Vec<String>>();
     if args.len() < 2 {
-        eprintln!("Expected bano csv file");
+        teprintln!("Expected bano csv file");
         return;
     }
 
     let mut db = DB::new("addresses.db", 10000, true).expect("failed to create DB");
     bano::import_addresses(&args[1], &mut db);
 
-    tprint!(
+    tprintln!(
         "Got {} addresses in {} cities (and {} errors)",
         db.get_nb_addresses(),
         db.get_nb_cities(),
         db.get_nb_errors(),
     );
-    println!("Errors by categories:");
+
+    teprintln!("Errors by categories:");
     let rows = db.get_nb_by_errors_kind();
     for (kind, nb) in rows {
-        println!("  {} => {} occurences", kind, nb);
+        teprintln!("  {} => {} occurences", kind, nb);
     }
 }

--- a/importers/openaddresses/src/main.rs
+++ b/importers/openaddresses/src/main.rs
@@ -1,25 +1,26 @@
 use std::env;
-use tools::{CompatibleDB, DB, tprint};
+use tools::{teprintln, tprintln, CompatibleDB, DB};
 
 fn main() {
     let args = env::args().collect::<Vec<String>>();
     if args.len() < 2 {
-        eprintln!("Expected openaddresses folder");
+        teprintln!("Expected openaddresses folder");
         return;
     }
 
     let mut db = DB::new("addresses.db", 10000, true).expect("failed to create DB");
     openaddresses::import_addresses(&args[1], &mut db);
 
-    tprint!(
+    tprintln!(
         "Got {} addresses in {} cities (and {} errors)",
         db.get_nb_addresses(),
         db.get_nb_cities(),
         db.get_nb_errors(),
     );
-    println!("Errors by categories:");
+
+    teprintln!("Errors by categories:");
     let rows = db.get_nb_by_errors_kind();
     for (kind, nb) in rows {
-        println!("  {} => {} occurences", kind, nb);
+        teprintln!("  {} => {} occurences", kind, nb);
     }
 }

--- a/importers/osm/src/main.rs
+++ b/importers/osm/src/main.rs
@@ -1,5 +1,5 @@
 use std::env;
-use tools::{self, CompatibleDB, DB, tprint};
+use tools::{self, teprintln, tprintln, CompatibleDB, DB};
 
 fn main() {
     let args = env::args().collect::<Vec<String>>();
@@ -9,15 +9,16 @@ fn main() {
     }
     let mut db = DB::new("addresses.db", 1000, true).expect("Failed to create DB");
     osm::import_addresses(&args[1], &mut db);
-    tprint!(
+    tprintln!(
         "Got {} addresses in {} cities (and {} errors)",
         db.get_nb_addresses(),
         db.get_nb_cities(),
         db.get_nb_errors(),
     );
-    println!("Errors by categories:");
+
+    teprintln!("Errors by categories:");
     let rows = db.get_nb_by_errors_kind();
     for (kind, nb) in rows {
-        println!("  {} => {} occurences", kind, nb);
+        teprintln!("  {} => {} occurences", kind, nb);
     }
 }

--- a/tools/src/lib.rs
+++ b/tools/src/lib.rs
@@ -8,18 +8,37 @@ pub fn get_time() -> String {
 }
 
 #[macro_export]
+macro_rules! tformat {
+    ($($arg:tt)*) => {{
+        format!("[{}] {}", $crate::get_time(), format!($($arg)*))
+    }}
+}
+
+#[macro_export]
 macro_rules! tprint {
     ($($arg:tt)*) => {{
-        use tools::get_time;
-        println!("[{}] {}", get_time(), format!($($arg)*));
+        print!("{}", $crate::tformat!($($arg)*));
     }}
 }
 
 #[macro_export]
 macro_rules! teprint {
     ($($arg:tt)*) => {{
-        use tools::get_time;
-        eprintln!("[{}] {}", get_time(), format!($($arg)*));
+        eprint!("{}", $crate::tformat!($($arg)*));
+    }}
+}
+
+#[macro_export]
+macro_rules! tprintln {
+    ($($arg:tt)*) => {{
+        println!("{}", $crate::tformat!($($arg)*));
+    }}
+}
+
+#[macro_export]
+macro_rules! teprintln {
+    ($($arg:tt)*) => {{
+        eprintln!("{}", $crate::tformat!($($arg)*));
     }}
 }
 


### PR DESCRIPTION
I tried to make logs a bit more readable, I'm not totally convinced by the result but at least I made sure all information is here:

```bash
$ cargo run --release -- --osm ~/data/luxembourg-latest.osm.pbf --openaddresses ~/data/addresses/openaddr/lu -o result.csv.gz
[13:56:11] Loading Osm addresses from path "/home/remi/data/luxembourg-latest.osm.pbf"...
[13:56:20] [OSM] Getting nodes ... 288013 nodes
[13:56:26] [OSM] Added 56955 addresses (total: 56955)
[13:56:26] Loading OpenAddress addresses from path "/home/remi/data/addresses/openaddr/lu"...
[13:56:31] [OA] Reading countrywide.csv                          ... 163975 addresses (total: 220930)
[13:56:31] [OA] Added 163975 addresses (total: 220930)
[13:56:31] Deduplication...
[13:56:31] Build index on hashes
[13:56:33] Compute hash collisions (220930 addresses, 4833846 hashes)
Filter colisions 100.0% [=========================================] 4833846/4833846, 53.5s (88.3 Ki/s)                                                                                                                                        
[13:57:31] Cleaning...
[13:57:31] Deleting 54711 addresses ... 166219 remain
[13:57:31] Cleaning database
[13:57:33] Vacuum database
[13:57:33] Write compressed CSV...
```