### PR TITLE
Optimize address count

### DIFF
--- a/deduplicator/Cargo.toml
+++ b/deduplicator/Cargo.toml
@@ -11,6 +11,10 @@ path = "src/bin/main.rs"
 [lib]
 path = "src/lib/mod.rs"
 
+[profile.release]
+lto = "fat"
+codegen-units = 1
+
 [dependencies]
 crossbeam-channel = "0.4"
 csv = "1.1"


### PR DESCRIPTION
Addresses are counted after each imported file, this was previously done by sending `SELECT COUNT(*)` query to SQLite, however it sounds that this statement takes a few second when importing a huge amount of data (it seems that it can raise to up to 9s when importing world addresses from both OSM and OA). Some of OpenAddresses data are very fragmented which leads to having 1671 CSV files in the dataset, so ~5 seconds per file adds up to 5 hours. 

This counts addresses internally to avoid the expensive request.

Note that counting addresses still have some cost since it currently requires to:

  - wait for all computation to be done (probably quick, the charge of each task is quite balanced)
  - commit current transaction (probably quick for small files)
  - restart working threads (probably enough)

Additionally I enabled [a few expensive compile time optimizations](https://github.com/QwantResearch/addresses-importer/pull/50/files#diff-8579fd1e9215e4177260363700702c94R14-R16) ([picked from here](https://deterministic.space/high-performance-rust.html)), I don't think we mind about compile time and it could add up to be useful on 3 day computation.