### PR TITLE
Query for conflicting hashes in parallel

### DIFF
--- a/deduplicator/Cargo.lock
+++ b/deduplicator/Cargo.lock
@@ -160,7 +160,7 @@ dependencies = [
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "openaddresses 0.1.0",
  "osm-addresses 0.1.0",
- "prog_rs 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prog_rs 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rpostal 0.1.0 (git+https://github.com/GuillaumeGomez/libpostal-rs.git)",
  "rusqlite 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "prog_rs"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "term_size 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1053,7 +1053,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum proc-macro-error-attr 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "23832e5eae6bac56bbac190500eef1aaede63776b5cd131eaa4ee7fe120cd892"
 "checksum proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)" = "ecd45702f76d6d3c75a80564378ae228a85f0b59d2f3ed43c91b4a69eb2ebfc5"
 "checksum proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3acb317c6ff86a4e579dfa00fc5e6cca91ecbb4e7eb2df0468805b674eb88548"
-"checksum prog_rs 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b936f1581e1ce446d1dc2d02c120e0f1f4e98d6dca774189a9a6f70285607715"
+"checksum prog_rs 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8b07b2f67a6d700b8f0b373e491bd105081e488d5ff32ee46f0e3bb0d0b75211"
 "checksum protobuf 2.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6686ddd96a8dbe2687b5f2a687b2cfb520854010ec480f2d74c32e7c9873d3c5"
 "checksum protobuf-codegen 2.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6456421eecf7fc72905868cd760c3e35848ded3552e480cfe67726ed4dbd8d23"
 "checksum protobuf-codegen-pure 2.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4a7cb42d5ab6073333be90208ab5ea6ab41c8f6803b35fd773a7572624cc15c9"

--- a/deduplicator/Cargo.toml
+++ b/deduplicator/Cargo.toml
@@ -29,7 +29,7 @@ libflate = "0.1"
 libsqlite3-sys = "0.17"
 num_cpus = "1.12"
 once_cell = "1.3.1"
-prog_rs = "0.1"
+prog_rs = "0.2"
 rpostal = { git = "https://github.com/GuillaumeGomez/libpostal-rs.git" }
 rusqlite = "0.21"
 structopt = { version = "0.3", default-features = false }

--- a/deduplicator/README.md
+++ b/deduplicator/README.md
@@ -20,25 +20,7 @@ importer.
 cargo run --release -- --osm-db path/to/osm_as_sqlite.db --openaddresses-db path/to/openaddresses_as_sqlite.db
 ```
 
-The output will be an SQLite database with a structure similar to the one
-described [here](https://github.com/QwantResearch/addresses-importer#importers):
-(this is probably temporary as we will probably prefer outputing a CSV file)
-
-```sql
-addresses(
-    id          INTEGER PRIMARY KEY AUTOINCREMENT,
-    lat         REAL NOT NULL,
-    lon         REAL NOT NULL,
-    number      TEXT,
-    street      TEXT NOT NULL,
-    unit        TEXT,
-    city        TEXT,
-    district    TEXT,
-    region      TEXT,
-    postcode    TEXT,
-    rank        REAL
-)
-```
+This will output a CSV file using the same format as OpenAddresses.
 
 If you want more information on the available options, use `-h` or `--help`:
 
@@ -52,7 +34,7 @@ Duplicate criteria
 Two addresses are considered duplicates if one of these two properties is true:
 
  - The distance between the two addresses is less than 100 meters and according
-   to libpostal and:
+   to libpostal:
      - have the same house number
      - are likely to be in the same street (if there is less than 10 meters
        between the two addresses, libpostal is allowed to only output
@@ -76,6 +58,6 @@ The deduplication is done through two steps:
     libpostal.
 
  2. Then, the pairs of addresses with conflicting hashes are extracted from the
-    database, for each of these pairs a more accurate criteria is applied to
+    database, for each of these pairs a more accurate criterion is applied to
     decide if it is actually a duplicate. Finally, for each actual duplicate,
     one of the two addresses is removed from the database.

--- a/deduplicator/src/lib/dedupe.rs
+++ b/deduplicator/src/lib/dedupe.rs
@@ -4,7 +4,6 @@ use std::hash::{Hash, Hasher};
 use geo::prelude::*;
 use geo::Point;
 use once_cell::sync::Lazy;
-use rpostal;
 use tools::Address;
 
 use crate::utils::{field_compare, opt_field_compare, postal_repr};

--- a/deduplicator/src/lib/deduplicator.rs
+++ b/deduplicator/src/lib/deduplicator.rs
@@ -188,7 +188,7 @@ impl Deduplicator {
         // speed.
         let mut progress = StepProgress::new()
             .with_refresh_delay(self.config.refresh_delay)
-            .with_prefix("Filter colisions")
+            .with_prefix("Filter collisions")
             .with_output_stream(prog_rs::OutputStream::StdErr);
 
         let count_addresses_before = self.db.count_addresses()?;

--- a/deduplicator/src/lib/deduplicator.rs
+++ b/deduplicator/src/lib/deduplicator.rs
@@ -1,4 +1,6 @@
 use std::cmp::max;
+use std::collections::HashSet;
+use std::convert::TryInto;
 use std::io::{stderr, Write};
 use std::mem::drop;
 use std::path::PathBuf;
@@ -9,10 +11,11 @@ use crossbeam_channel as channel;
 use importer_openaddresses::OpenAddress;
 use itertools::Itertools;
 use prog_rs::prelude::*;
+use prog_rs::StepProgress;
 use rusqlite::DropBehavior;
 use tools::Address;
 
-use crate::db_hashes::{DbHashes, HashIterItem};
+use crate::db_hashes::DbHashes;
 use crate::dedupe::{hash_address, is_duplicate};
 use crate::utils::is_constraint_violation_error;
 
@@ -73,51 +76,49 @@ impl Deduplicator {
         )?)
     }
 
-    /// Compute duplicate pairs inserted in the deduplicator. A set of addresses that need to be
-    /// deleted will be computed and inserted into the database.
     pub fn compute_duplicates(&mut self) -> rusqlite::Result<()> {
         teprintln!("Build index on hashes");
         self.db.create_hashes_index()?;
 
-        // --- Query collisions from DB
-        let count_addresses_before = self.db.count_addresses()?;
-        let count_hashes = self.db.count_hashes()?;
-
-        teprintln!(
-            "Compute hash collisions ({} addresses, {} hashes)",
-            count_addresses_before,
-            count_hashes
-        );
-
-        let conn_get_collisions = self.db.get_conn()?;
-        let mut sorted_hashes = DbHashes::get_collisions_iter(&conn_get_collisions)?;
-
         // Eliminate false positives in parallel using following pipeline:
         //
-        // [     col_sender     ] main thread
+        // [     del_sender      ] worker threads
         //            |
-        //            |  (address, rank)
+        //            |  (new_count, address_id) : update progress and an address to remove
         //            v
-        // [    col_receiver    ]
-        // [         |||        ] worker threads
-        // [     del_sender     ]
-        //            |
-        //            |  (address, rank, hashes)
-        //            v
-        // [    del_receiver    ] writer thread
+        // [    del_receiver     ] main thread
 
-        let nb_workers = max(3, self.config.nb_threads) - 2;
-        let (col_sender, col_receiver) = channel::bounded::<Vec<HashIterItem>>(CHANNELS_SIZE);
-        let (del_sender, del_receiver) = channel::bounded(CHANNELS_SIZE);
+        let nb_workers = max(2, self.config.nb_threads) - 1;
+        let (del_sender, del_receiver) = channel::unbounded();
 
         // --- Init worker threads
 
-        for _ in 0..nb_workers {
-            let col_receiver = col_receiver.clone();
+        for part in 0..nb_workers {
             let del_sender = del_sender.clone();
+            let conn = self.db.get_conn()?;
 
             thread::spawn(move || {
-                for mut pack in col_receiver {
+                let mut sorted_hashes =
+                    DbHashes::get_collisions_iter_for_parts(&conn, part, nb_workers)
+                        .expect("failed initializing collisions request");
+
+                let conflicting_packs = sorted_hashes
+                    .iter()
+                    .expect("failed reading conflicting hashes")
+                    .filter_map(|item| {
+                        item.map_err(|err| teprintln!("Failed retrieving hash: {}", err))
+                            .ok()
+                    })
+                    .group_by(|addr| addr.hash);
+
+                // Keep track of the number of hashes handled since last time data was sent into
+                // the channel. This counter will be sent and reset at each communication.
+                let mut addr_since_last_send = 0;
+
+                for (_key, pack) in conflicting_packs.into_iter() {
+                    let mut pack: Vec<_> = pack.collect();
+                    addr_since_last_send += pack.len();
+
                     if pack.len() > 5000 {
                         // In practice this should not happen often, however in the case where this
                         // issue is raised, it would be necessary to implement a specific way of
@@ -166,9 +167,10 @@ impl Deduplicator {
                             .any(|kept| is_duplicate(&item.address, &kept.address));
 
                         if item_is_duplicate {
-                            del_sender.send(item.id).expect(
+                            del_sender.send((addr_since_last_send, item.id)).expect(
                                 "failed sending id to delete: channel may have closed to early",
                             );
+                            addr_since_last_send = 0;
                         } else {
                             kept_items.push(item);
                         }
@@ -177,66 +179,64 @@ impl Deduplicator {
             });
         }
 
-        // Drop channels that were cloned before being sent
-        drop(col_receiver);
+        // Drop sending channel, receiving channel will close as soon as all threads finished.
         drop(del_sender);
 
-        // --- Init writer thread
+        // --- Compute stats
 
-        let mut conn_insert = self.db.get_conn()?;
-
-        let writer_thread = thread::spawn(move || {
-            let mut tran_insert = conn_insert
-                .transaction()
-                .expect("failed to init transaction");
-            tran_insert.set_drop_behavior(DropBehavior::Commit);
-            let mut inserter =
-                DbHashes::get_inserter(&mut tran_insert).expect("failed to init inserter");
-
-            // Collect the list of addresses to remove
-            let to_delete: std::collections::HashSet<_> = del_receiver.iter().collect();
-
-            for id in to_delete {
-                match inserter.insert_to_delete(id) {
-                    Err(err) if !is_constraint_violation_error(&err) => {
-                        teprintln!("Failed to insert id to delete in the database: {}", err)
-                    }
-                    _ => (),
-                }
-            }
-        });
-
-        // --- Send conflicting pairs into channels
-
-        // Pack conflicting items together
-        let count_collisions = self.db.count_collisions()? as usize;
-        let conflicting_packs = sorted_hashes
-            .iter()?
-            .progress()
+        // Initialize progress bar before computing stats to initialize the timer used to compute
+        // speed.
+        let mut progress = StepProgress::new()
             .with_refresh_delay(self.config.refresh_delay)
-            .with_iter_size(count_collisions)
             .with_prefix("Filter colisions")
-            .with_output_stream(prog_rs::OutputStream::StdErr)
-            .filter_map(|item| {
-                item.map_err(|err| teprintln!("Failed retrieving hash: {}", err))
-                    .ok()
+            .with_output_stream(prog_rs::OutputStream::StdErr);
+
+        let count_addresses_before = self.db.count_addresses()?;
+        let count_hashes = self.db.count_hashes()?;
+
+        teprintln!(
+            "Compute hash collisions ({} addresses, {} hashes)",
+            count_addresses_before,
+            count_hashes
+        );
+
+        let count_collisions = self
+            .db
+            .count_collisions()?
+            .try_into()
+            .expect("overflow for count of collisions");
+
+        progress = progress.with_max_step(count_collisions);
+
+        // --- Collect addresses to remove
+
+        let to_delete: HashSet<_> = del_receiver
+            .iter()
+            .map(|(new_progress, id)| {
+                progress.step(new_progress);
+                id
             })
-            .group_by(|addr| addr.hash);
+            .collect();
 
-        // Remove packs of single elements
-        let conflicting_packs = conflicting_packs
-            .into_iter()
-            .map(|(_key, pack)| pack.collect::<Vec<_>>())
-            .filter(|pack| pack.len() >= 2);
+        progress.finish();
 
-        for pack in conflicting_packs {
-            col_sender
-                .send(pack)
-                .expect("failed to send collision: channel may have closed too early");
+        // --- Delete conflicting addresses
+
+        let mut conn = self.db.get_conn()?;
+        let mut tran_insert = conn.transaction().expect("failed to init transaction");
+        tran_insert.set_drop_behavior(DropBehavior::Commit);
+        let mut inserter =
+            DbHashes::get_inserter(&mut tran_insert).expect("failed to init inserter");
+
+        for id in to_delete {
+            match inserter.insert_to_delete(id) {
+                Err(err) if !is_constraint_violation_error(&err) => {
+                    teprintln!("Failed to insert id to delete in the database: {}", err)
+                }
+                _ => {}
+            }
         }
 
-        drop(col_sender);
-        writer_thread.join().expect("failed joining writing thread");
         Ok(())
     }
 

--- a/deduplicator/src/lib/tests.rs
+++ b/deduplicator/src/lib/tests.rs
@@ -8,10 +8,10 @@ use std::path::PathBuf;
 use importer_openaddresses::OpenAddress;
 use rusqlite::{Connection, NO_PARAMS};
 use tempdir::TempDir;
-use tools::Address;
-use tools::CompatibleDB;
+use tools::{Address, CompatibleDB};
 
 use crate::deduplicator::{DedupeConfig, Deduplicator};
+use crate::utils::partition;
 
 const DB_NO_DUPES: &str = "data/tests/no_dupes.sql";
 const DB_WITH_DUPES: &str = "data/tests/with_dupes.sql";
@@ -181,4 +181,21 @@ fn csv_is_complete() -> rusqlite::Result<()> {
     // Compare results
     assert_same_addresses(output_addresses, csv_addresses);
     Ok(())
+}
+
+#[test]
+fn test_partition() {
+    for min_val in 0..=100 {
+        for max_val in min_val..=100 {
+            for nb_parts in 1..=10 {
+                assert_eq!(partition(min_val..=max_val, nb_parts).count(), nb_parts);
+                assert_eq!(
+                    partition(min_val..=max_val, nb_parts)
+                        .flatten()
+                        .collect::<Vec<_>>(),
+                    (min_val..=max_val).collect::<Vec<_>>()
+                );
+            }
+        }
+    }
 }

--- a/deduplicator/src/lib/utils.rs
+++ b/deduplicator/src/lib/utils.rs
@@ -24,21 +24,23 @@ use tools::{Address, CompatibleDB};
 ///
 /// assert_eq!(partition(0..=99, 2).collect::<Vec<_>>(), vec![0..=49, 50..=99]);
 /// ```
+#[allow(clippy::range_minus_one)]
 pub fn partition(
     range: RangeInclusive<i64>,
     nb_parts: usize,
 ) -> impl Iterator<Item = RangeInclusive<i64>> {
     let min = i128::from(*range.start());
-    let max = i128::from(*range.end()) + 1i128;
+    let max = i128::from(*range.end()) + 1;
     let nb_parts = i128::try_from(nb_parts).expect("overflow when computing partitions");
 
-    let bounds = (0..=nb_parts).map(move |part| min + part * (max - min) / nb_parts);
+    let bounds = (0..=nb_parts)
+        .map(move |part| min + part * (max - min) / nb_parts)
+        .map(|bound| bound.try_into().expect("bounds should fit in i64"));
 
-    bounds.clone().zip(bounds.skip(1)).map(|(start, end)| {
-        let start: i64 = start.try_into().expect("math error in partition");
-        let end: i64 = end.try_into().expect("math error in partition");
-        start..=(end - 1)
-    })
+    bounds
+        .clone()
+        .zip(bounds.skip(1))
+        .map(|(start, end)| start..=(end - 1))
 }
 
 /// Parse a string into a duration from a number of milliseconds.


### PR DESCRIPTION
(Note that this is based on https://github.com/QwantResearch/addresses-importer/pull/50, which is actually not mandatory, I can easily rebase if necessary)

I properly finished this PR as the speedup sounds promising and
resulting code is arguably simpler (at least more sequential).

On master this step uses 3 kinds of thread:

 1. a reader, which sends the query to SQLite, parse the result and sends
    conflicting packs of addresses to the workers.
 2. workers, which extensively checks for each pair of addresses if they are
    actually the same address, and sends addresses that need to be removed to
    the collector.
 3. a collector which is just collecting addresses to remove into a HashMap (an
    address can be involved in several conflicting hashes).

The issue with this approach is that only the amount of worker can scale with
the available number of CPUs, however the reader also handles a lot of
computation.

This PR merges the behaviour of the reader and the workers into a single kind
of threads:

 1. the workers query SQLite for only a part of the result, and handles the
    conflicts without any cross-thread communication.
 2. a collector is still used to collect addresses to remove into an HashMap,
    and is also handful to monitor advancement.

Tests
---

All following tests were built on BANO, the duration and speed columns are
computed considering only the modified step.

On my personal computer (8 cores), the workers are already working at full
speed with previous behaviour, we can't except any big improvement here:

| branch | duration |  speed |
|:------:|:--------:|:------:|
| master |   932s   | 56 K/s |
|  HEAD  |   954s   | 55 K/s |

As a proof that SQLite requests are able to scale when parallelized, here is an
experiment where the workers don't have to do any computation to handle packs
(thus, only the SQLite requests is being performed in worker threads, nothing
is done to check if addresses are actual duplicates of each other):

|    branch    | duration |  speed  |
|:------------:|:--------:|:-------:|
|    master    |   554s   |  97 K/s |
|  HEAD (-n 1) |   447s   | 116 K/s |
|  HEAD (-n 8) |   124s   | 420 K/s |
| HEAD (-n 40) |   119s   | 425 K/s |

Several nice notes:

 - this is faster with a single worker thread (against old behavior enforcing a
   single reader), the reason for this might be that there is less channel
   communications?

 - using a huge amount of threads doesn't seem to have any impact on
   performances (we still need to watch how this will behave when the IO is
   overwhelmed)
