### PR TITLE
update to rust 2021 and debian bullseye

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1-slim-stretch as builder
+FROM rust:1-slim-bullseye as builder
 
 WORKDIR /srv/addresses-importer
 

--- a/deduplicator/Cargo.toml
+++ b/deduplicator/Cargo.toml
@@ -2,7 +2,7 @@
 name = "deduplicator"
 version = "0.1.0"
 authors = ["Rémi Dupré <r.dupre@qwant.com>"]
-edition = "2018"
+edition = "2021"
 
 [[bin]]
 name = "deduplicator"

--- a/deduplicator/src/lib/db_hashes.rs
+++ b/deduplicator/src/lib/db_hashes.rs
@@ -325,7 +325,7 @@ impl DbHashes {
     pub fn cleanup_database(&self) -> rusqlite::Result<()> {
         let conn = self.get_conn()?;
 
-        for db in [TABLE_HASHES, TABLE_TO_DELETE].iter() {
+        for db in [TABLE_HASHES, TABLE_TO_DELETE] {
             conn.execute_batch(&format!("DROP TABLE {};", db))?;
         }
 

--- a/deduplicator/src/lib/db_hashes.rs
+++ b/deduplicator/src/lib/db_hashes.rs
@@ -2,7 +2,6 @@
 //! it. This database will be used to save hashes of all imported addresses and compute collisions
 //! between them.
 
-use std::convert::TryInto;
 use std::path::PathBuf;
 
 use rusqlite::{Connection, Statement, ToSql, Transaction, NO_PARAMS};

--- a/deduplicator/src/lib/deduplicator.rs
+++ b/deduplicator/src/lib/deduplicator.rs
@@ -1,6 +1,5 @@
 use std::cmp::max;
 use std::collections::HashSet;
-use std::convert::TryInto;
 use std::io::{stderr, Write};
 use std::mem::drop;
 use std::path::PathBuf;

--- a/deduplicator/src/lib/tests.rs
+++ b/deduplicator/src/lib/tests.rs
@@ -1,6 +1,5 @@
 extern crate tempdir;
 
-use std::convert::TryInto;
 use std::fs::File;
 use std::io::prelude::*;
 use std::path::PathBuf;
@@ -17,7 +16,7 @@ const DB_NO_DUPES: &str = "data/tests/no_dupes.sql";
 const DB_WITH_DUPES: &str = "data/tests/with_dupes.sql";
 
 /// Create an SQLite database from Sql dump
-fn load_dump(path: &PathBuf) -> rusqlite::Result<Connection> {
+fn load_dump(path: PathBuf) -> rusqlite::Result<Connection> {
     let mut sql_buff = String::new();
     let mut file = File::open(path).expect("failed to load test database");
     file.read_to_string(&mut sql_buff)
@@ -56,8 +55,8 @@ fn insert_addresses(
 }
 
 fn assert_same_addresses(mut addresses_1: Vec<Address>, mut addresses_2: Vec<Address>) {
-    addresses_1.sort_by(|addr_1, addr_2| addr_1.partial_cmp(&addr_2).unwrap());
-    addresses_2.sort_by(|addr_1, addr_2| addr_1.partial_cmp(&addr_2).unwrap());
+    addresses_1.sort_by(|addr_1, addr_2| addr_1.partial_cmp(addr_2).unwrap());
+    addresses_2.sort_by(|addr_1, addr_2| addr_1.partial_cmp(addr_2).unwrap());
 
     assert_eq!(addresses_1.len(), addresses_2.len());
 
@@ -73,7 +72,7 @@ fn database_complete() -> rusqlite::Result<()> {
     let output_path = tmp_dir.path().join("addresses.db");
 
     // Read input database
-    let input_addresses = load_addresses_from_db(&load_dump(&DB_NO_DUPES.into())?)?;
+    let input_addresses = load_addresses_from_db(&load_dump(DB_NO_DUPES.into())?)?;
     let mut dedupe = Deduplicator::new(
         tmp_dir.path().join("addresses.db"),
         DedupeConfig::default(),
@@ -98,7 +97,7 @@ fn remove_exact_duplicates() -> rusqlite::Result<()> {
     let output_path = tmp_dir.path().join("addresses.db");
 
     // Read input database
-    let input_addresses = load_addresses_from_db(&load_dump(&DB_NO_DUPES.into())?)?;
+    let input_addresses = load_addresses_from_db(&load_dump(DB_NO_DUPES.into())?)?;
     let mut dedupe = Deduplicator::new(
         tmp_dir.path().join("addresses.db"),
         DedupeConfig::default(),
@@ -128,7 +127,7 @@ fn remove_close_duplicates() -> rusqlite::Result<()> {
     let output_path = tmp_dir.path().join("addresses.db");
 
     // Read input database
-    let input_addresses = load_addresses_from_db(&load_dump(&DB_WITH_DUPES.into())?)?;
+    let input_addresses = load_addresses_from_db(&load_dump(DB_WITH_DUPES.into())?)?;
     let mut dedupe = Deduplicator::new(
         tmp_dir.path().join("addresses.db"),
         DedupeConfig::default(),
@@ -152,13 +151,13 @@ fn csv_is_complete() -> rusqlite::Result<()> {
     let output_csv_path = tmp_dir.path().join("addresses.csv.gz");
 
     // Read input database
-    let input_addresses = load_addresses_from_db(&load_dump(&DB_NO_DUPES.into())?)?;
+    let input_addresses = load_addresses_from_db(&load_dump(DB_NO_DUPES.into())?)?;
     let mut dedupe = Deduplicator::new(
         tmp_dir.path().join("addresses.db"),
         DedupeConfig::default(),
         None,
     )?;
-    insert_addresses(&mut dedupe, input_addresses.clone())?;
+    insert_addresses(&mut dedupe, input_addresses)?;
 
     // Dump CSV
     let file = File::create(&output_csv_path).expect("failed to create dump file");

--- a/deduplicator/src/lib/utils.rs
+++ b/deduplicator/src/lib/utils.rs
@@ -1,7 +1,6 @@
 //! Generic utilities.
 
 use std::borrow::Borrow;
-use std::convert::{TryFrom, TryInto};
 use std::ffi::CString;
 use std::num::ParseIntError;
 use std::ops::RangeInclusive;

--- a/importers/bano/Cargo.toml
+++ b/importers/bano/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bano"
 version = "0.1.0"
 authors = ["Guillaume Gomez <guillaume1.gomez@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 csv = "1.1"

--- a/importers/openaddresses/Cargo.toml
+++ b/importers/openaddresses/Cargo.toml
@@ -2,7 +2,7 @@
 name = "openaddresses"
 version = "0.1.0"
 authors = ["Guillaume Gomez <guillaume1.gomez@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 csv = "1.1"

--- a/importers/osm/Cargo.toml
+++ b/importers/osm/Cargo.toml
@@ -2,7 +2,7 @@
 name = "osm-addresses"
 version = "0.1.0"
 authors = ["Guillaume Gomez <guillaume1.gomez@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 bincode = "1.1"

--- a/importers/osm/src/lib.rs
+++ b/importers/osm/src/lib.rs
@@ -422,7 +422,7 @@ fn handle_obj<T: CompatibleDB>(obj: StoredObj, db: &mut T) {
         },
         StoredObj::Way(way, nodes) => {
             if let Some((lat, lon)) = get_way_lat_lon(&nodes) {
-                db.insert(new_address(&way.tags(), lat, lon));
+                db.insert(new_address(way.tags(), lat, lon));
             }
         }
         StoredObj::Relation(r, objs) => {
@@ -444,7 +444,7 @@ fn handle_obj<T: CompatibleDB>(obj: StoredObj, db: &mut T) {
                     }
                     StoredObj::Way(w, nodes) if w.tags().iter().any(is_valid_housenumber_tag) => {
                         if let Some((lat, lon)) = get_way_lat_lon(&nodes) {
-                            let mut addr = new_address(&w.tags(), lat, lon);
+                            let mut addr = new_address(w.tags(), lat, lon);
                             addr.street = Some(addr_name.clone());
                             db.insert(addr);
                         }
@@ -512,7 +512,7 @@ mod tests {
         let pbf_file = "test-files/osm_input.pbf";
         let db_file = "check_relations.db";
 
-        let mut db = DB::new(&db_file, 0, true).expect("Failed to initialize DB");
+        let mut db = DB::new(db_file, 0, true).expect("Failed to initialize DB");
         let db_nodes = get_nodes(&pbf_file);
         assert_eq!(db_nodes.count(), 1406);
         iter_nodes(db_nodes, &mut db);

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tools"
 version = "0.1.0"
 authors = ["Guillaume Gomez <guillaume1.gomez@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 rusqlite = "0.21"

--- a/tools/src/lib.rs
+++ b/tools/src/lib.rs
@@ -1,5 +1,4 @@
 use rusqlite::{Connection, DropBehavior, Row, ToSql, NO_PARAMS};
-use std::convert::{TryFrom, TryInto};
 use std::fs;
 
 /// Returns a `String` representing the current time under the form "HH:MM:SS".


### PR DESCRIPTION
The base image for stretch doesn't appear to be maintained anymore.

Also, let's update to Rust 2021, there is basically no pain to do that and it allows for slight cleanups.