### PR TITLE
osm importer: make path to nodes db configurable

### DIFF
--- a/importers/osm/src/main.rs
+++ b/importers/osm/src/main.rs
@@ -8,7 +8,7 @@ fn main() {
         return;
     }
     let mut db = DB::new("addresses.db", 1000, true).expect("Failed to create DB");
-    osm::import_addresses(&args[1], &mut db);
+    osm::import_addresses(args[1].as_ref(), "nodes.db".as_ref(), &mut db);
     tprintln!(
         "Got {} addresses in {} cities (and {} errors)",
         db.get_nb_addresses(),


### PR DESCRIPTION
Reading an OSM file while building relations can't be done in streaming, so some data is loaded in an SQLite database during computation. This database was built at an hard-coded path, which is an issue in our argo workflows, where we enforce immutable databases.

This just adds a `--node-db` parameter to the command line to change the path of this database.