### PR TITLE
do not apply deletion of addresses to DB, only to output

### DIFF
--- a/deduplicator/src/bin/main.rs
+++ b/deduplicator/src/bin/main.rs
@@ -168,6 +168,7 @@ fn main() -> rusqlite::Result<()> {
 
     tprintln!("Deduplication...");
     deduplication.compute_duplicates()?;
+    deduplication.cleanup_database()?;
 
     // --- Dump CSV
 

--- a/deduplicator/src/bin/main.rs
+++ b/deduplicator/src/bin/main.rs
@@ -169,9 +169,6 @@ fn main() -> rusqlite::Result<()> {
     tprintln!("Deduplication...");
     deduplication.compute_duplicates()?;
 
-    tprintln!("Cleaning...");
-    deduplication.apply_deletions()?;
-
     // --- Dump CSV
 
     tprintln!("Write compressed CSV...");

--- a/deduplicator/src/lib/deduplicator.rs
+++ b/deduplicator/src/lib/deduplicator.rs
@@ -225,45 +225,38 @@ impl Deduplicator {
         progress.finish();
 
         // --- Delete conflicting addresses
+        self.db.insert_to_delete(to_delete);
+        Ok(())
+    }
 
-        let mut conn = self.db.get_conn()?;
-        let mut tran_insert = conn.transaction().expect("failed to init transaction");
-        tran_insert.set_drop_behavior(DropBehavior::Commit);
-        let mut inserter =
-            DbHashes::get_inserter(&mut tran_insert).expect("failed to init inserter");
+    /// Swipe hashes from database and output stats
+    pub fn apply_deletions(&self) -> rusqlite::Result<()> {
+        self.db.cleanup_database()?;
+        let count_to_delete = self.db.count_to_delete() as i64;
 
-        for id in to_delete {
-            match inserter.insert_to_delete(id) {
-                Err(err) if !is_constraint_violation_error(&err) => {
-                    teprintln!("Failed to insert id to delete in the database: {}", err)
-                }
-                _ => {}
-            }
-        }
+        teprintln!(
+            "Deleting {} addresses ... {} will remain",
+            count_to_delete,
+            self.db.count_addresses()? - count_to_delete
+        );
 
         Ok(())
     }
 
-    /// Delete the addresses that were marked to be deleted.
-    pub fn apply_deletions(&self) -> rusqlite::Result<()> {
-        let count_to_delete = self.db.count_to_delete()?;
-        teprint!("Deleting {} addresses ...\r", count_to_delete);
-
-        self.db.apply_addresses_to_delete()?;
-        teprintln!(
-            "Deleting {} addresses ... {} remain",
-            count_to_delete,
-            self.db.count_addresses()?
-        );
-
-        Ok(())
+    pub fn collect_addresses<T>(&self) -> rusqlite::Result<T>
+    where
+        T: FromIterator<Address>,
+    {
+        let conn = self.db.get_conn()?;
+        let buff: Result<T, _> = self.db.get_addresses(&conn)?.iter()?.collect();
+        buff
     }
 
     /// Dump addresses stored in the deduplicator into OpenAddresses's CSV format.
     pub fn openaddresses_dump<W: Write>(&self, mut stream: W) -> rusqlite::Result<()> {
         // Fetch addresses
         let conn = self.db.get_conn()?;
-        let mut addresses = DbHashes::get_addresses(&conn)?;
+        let mut addresses = self.db.get_addresses(&conn)?;
 
         // Dump into stream
         {

--- a/deduplicator/src/lib/deduplicator.rs
+++ b/deduplicator/src/lib/deduplicator.rs
@@ -230,7 +230,7 @@ impl Deduplicator {
     }
 
     /// Swipe hashes from database and output stats
-    pub fn apply_deletions(&self) -> rusqlite::Result<()> {
+    pub fn cleanup_database(&self) -> rusqlite::Result<()> {
         self.db.cleanup_database()?;
         let count_to_delete = self.db.count_to_delete() as i64;
 
@@ -476,22 +476,10 @@ where
             .expect("failed sending address: channel may have closed too early")
     }
 
-    fn get_nb_cities(&mut self) -> i64 {
-        self.borrow_db(|db| db.count_cities())
-            .map_err(|err| eprintln!("Failed counting cities: '{}'", err))
-            .unwrap_or(0)
-    }
-
     fn get_nb_addresses(&mut self) -> i64 {
         self.flush()
             .expect("failed flushing before counting addresses");
         self.count_addresses
-    }
-
-    fn get_address(&mut self, housenumber: i32, street: &str) -> Vec<Address> {
-        self.borrow_db(|db| db.get_addresses_by_street(housenumber, street))
-            .map_err(|err| eprintln!("Error while retrieving addresses by street: '{}'", err))
-            .unwrap_or_default()
     }
 
     // Current implementation for the deduplication actually doesn't log errors.

--- a/deduplicator/src/lib/tests.rs
+++ b/deduplicator/src/lib/tests.rs
@@ -79,7 +79,7 @@ fn database_complete() -> rusqlite::Result<()> {
     )?;
     insert_addresses(&mut dedupe, input_addresses.clone())?;
     dedupe.compute_duplicates()?;
-    dedupe.apply_deletions()?;
+    dedupe.cleanup_database()?;
 
     // Read output database
     let output_addresses = dedupe.collect_addresses()?;
@@ -108,7 +108,7 @@ fn remove_exact_duplicates() -> rusqlite::Result<()> {
     }
 
     dedupe.compute_duplicates()?;
-    dedupe.apply_deletions()?;
+    dedupe.cleanup_database()?;
 
     // Read output database
     let output_addresses = dedupe.collect_addresses()?;
@@ -132,7 +132,7 @@ fn remove_close_duplicates() -> rusqlite::Result<()> {
     )?;
     insert_addresses(&mut dedupe, input_addresses)?;
     dedupe.compute_duplicates()?;
-    dedupe.apply_deletions()?;
+    dedupe.cleanup_database()?;
 
     // Read output database
     let output_addresses: Vec<_> = dedupe.collect_addresses()?;

--- a/deduplicator/src/lib/tests.rs
+++ b/deduplicator/src/lib/tests.rs
@@ -69,7 +69,6 @@ fn assert_same_addresses(mut addresses_1: Vec<Address>, mut addresses_2: Vec<Add
 #[test]
 fn database_complete() -> rusqlite::Result<()> {
     let tmp_dir = TempDir::new("output").unwrap();
-    let output_path = tmp_dir.path().join("addresses.db");
 
     // Read input database
     let input_addresses = load_addresses_from_db(&load_dump(DB_NO_DUPES.into())?)?;
@@ -83,7 +82,7 @@ fn database_complete() -> rusqlite::Result<()> {
     dedupe.apply_deletions()?;
 
     // Read output database
-    let output_addresses = load_addresses_from_db(&Connection::open(&output_path)?)?;
+    let output_addresses = dedupe.collect_addresses()?;
 
     // Compare results
     assert_same_addresses(input_addresses, output_addresses);
@@ -94,7 +93,6 @@ fn database_complete() -> rusqlite::Result<()> {
 #[test]
 fn remove_exact_duplicates() -> rusqlite::Result<()> {
     let tmp_dir = TempDir::new("output").unwrap();
-    let output_path = tmp_dir.path().join("addresses.db");
 
     // Read input database
     let input_addresses = load_addresses_from_db(&load_dump(DB_NO_DUPES.into())?)?;
@@ -113,7 +111,7 @@ fn remove_exact_duplicates() -> rusqlite::Result<()> {
     dedupe.apply_deletions()?;
 
     // Read output database
-    let output_addresses = load_addresses_from_db(&Connection::open(&output_path)?)?;
+    let output_addresses = dedupe.collect_addresses()?;
 
     // Compare results
     assert_same_addresses(input_addresses, output_addresses);
@@ -124,7 +122,6 @@ fn remove_exact_duplicates() -> rusqlite::Result<()> {
 #[test]
 fn remove_close_duplicates() -> rusqlite::Result<()> {
     let tmp_dir = TempDir::new("output").unwrap();
-    let output_path = tmp_dir.path().join("addresses.db");
 
     // Read input database
     let input_addresses = load_addresses_from_db(&load_dump(DB_WITH_DUPES.into())?)?;
@@ -138,7 +135,7 @@ fn remove_close_duplicates() -> rusqlite::Result<()> {
     dedupe.apply_deletions()?;
 
     // Read output database
-    let output_addresses = load_addresses_from_db(&Connection::open(&output_path)?)?;
+    let output_addresses: Vec<_> = dedupe.collect_addresses()?;
     assert_eq!(output_addresses.len(), 10);
     Ok(())
 }

--- a/importers/bano/src/main.rs
+++ b/importers/bano/src/main.rs
@@ -12,9 +12,8 @@ fn main() {
     bano::import_addresses(&args[1], &mut db);
 
     tprintln!(
-        "Got {} addresses in {} cities (and {} errors)",
+        "Got {} addresses (and {} errors)",
         db.get_nb_addresses(),
-        db.get_nb_cities(),
         db.get_nb_errors(),
     );
 

--- a/importers/openaddresses/src/main.rs
+++ b/importers/openaddresses/src/main.rs
@@ -12,9 +12,8 @@ fn main() {
     openaddresses::import_addresses(&args[1], &mut db);
 
     tprintln!(
-        "Got {} addresses in {} cities (and {} errors)",
+        "Got {} addresses (and {} errors)",
         db.get_nb_addresses(),
-        db.get_nb_cities(),
         db.get_nb_errors(),
     );
 

--- a/importers/osm/src/lib.rs
+++ b/importers/osm/src/lib.rs
@@ -488,9 +488,6 @@ mod tests {
         import_addresses(pbf_file.as_ref(), &mut db);
         assert_eq!(db.get_nb_addresses(), 361);
 
-        let addr = db.get_address(2, "Place de la Forêt de Cruye");
-        assert_eq!(addr.len(), 1);
-
         let _ = std::fs::remove_file(db_file); // we ignore any potential error
     }
 }

--- a/importers/osm/src/main.rs
+++ b/importers/osm/src/main.rs
@@ -10,9 +10,8 @@ fn main() {
     let mut db = DB::new("addresses.db", 1000, true).expect("Failed to create DB");
     osm::import_addresses(args[1].as_ref(), &mut db);
     tprintln!(
-        "Got {} addresses in {} cities (and {} errors)",
+        "Got {} addresses (and {} errors)",
         db.get_nb_addresses(),
-        db.get_nb_cities(),
         db.get_nb_errors(),
     );
 


### PR DESCRIPTION
Current behavior is the following:
 1. compute the list of address IDs to delete
 2. write this list of IDs to a SQLite table
 3. perform a request to remove addresses that have an ID in this table

These last two steps seem to take about half a day in our integration environment while they perform some overly complicated tasks.

This PR removes these last two steps and just reuses the `HashSet` computed at step 1 to filter addresses (with no I/O) while we output them for the final dump.